### PR TITLE
Update upload pages artifacts to v3

### DIFF
--- a/.github/workflows/gh-pages-deploy.yaml
+++ b/.github/workflows/gh-pages-deploy.yaml
@@ -77,7 +77,7 @@ jobs:
           # token:
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload dist dir
           path: './dist'


### PR DESCRIPTION
github no longer allows actions/upload-artifacts v3 or earlier (https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/).  update to actions/upload-pages-artifacts@v3 which uses the v4 version of upload-artifacts.