### PR TITLE
projects_component: Replace patina repo link with coming soon text

### DIFF
--- a/src/components/projects_component.rs
+++ b/src/components/projects_component.rs
@@ -130,14 +130,16 @@ pub fn ProjectsComponent() -> impl IntoView {
                                 <span style="text-decoration: none;">{"→ "}</span>
                                 <span style="text-decoration: underline;">{"Read the Boot Firmware Guide"}</span>
                             </a>
-                            // <a
-                            //     href="https://github.com/OpenDevicePartnership/patina"
-                            //     class="link"
-                            //     style="text-decoration: none;"
-                            // >
-                            //     <span style="text-decoration: none;">{"→ "}</span>
-                            //     <span style="text-decoration: underline;">{"View Patina on GitHub"}</span>
-                            // </a>
+                            <span
+                                class="p2"
+                                style="
+                                    display: block;
+                                    text-align: left;
+                                    color: #888;
+                                "
+                            >
+                                {"Patina GitHub repo coming soon!"}
+                            </span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The repo is not public. To make this not appear as a broken link and provide proper context, say the repo is coming soon.

---

**Light Mode**

<img width="1587" height="529" alt="image" src="https://github.com/user-attachments/assets/ddc130ad-42ee-455f-a4c9-d4102f47775f" />

---

**Dark Mode***

<img width="1598" height="534" alt="image" src="https://github.com/user-attachments/assets/50b7a9c1-63f3-4314-b224-16aff173cd31" />