### PR TITLE
fix: separate clippy and fmt commands

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yaml
+++ b/.github/workflows/cloudflare-pages-deploy.yaml
@@ -36,7 +36,9 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: lint
-        run: cargo clippy & cargo fmt --check
+        run: |
+          cargo clippy -- -D warnings
+          cargo fmt --check
 
       # If using tailwind...
       # - name: Download and install tailwindcss binary

--- a/src/pages/announcements.rs
+++ b/src/pages/announcements.rs
@@ -77,7 +77,6 @@ pub fn AnnouncementsPage() -> impl IntoView {
     // Set selected from query param if present
     {
         let location = location.clone();
-        let set_selected = set_selected.clone();
         let announcements_clone = announcements.clone();
         Effect::new(move |_| {
             let search = location.search.get();

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,8 +1,8 @@
 use crate::components::documentation_training::{DocLink, DocumentationTraining};
-use crate::components::partners_grid::PartnersGrid;
 use crate::components::footer::Footer;
 use crate::components::header::Header;
 use crate::components::main::Main;
+use crate::components::partners_grid::PartnersGrid;
 
 use leptos::prelude::*;
 


### PR DESCRIPTION
This pull request updates the linting step in the GitHub Actions workflow to enforce stricter linting rules by treating Clippy warnings as errors. This ensures that any new warnings will fail the CI, helping maintain code quality.

- **CI/CD Improvements:**
  * Updated the `lint` job in `.github/workflows/cloudflare-pages-deploy.yaml` to run `cargo clippy` with the `-D warnings` flag, so warnings are now treated as errors and will fail the build.